### PR TITLE
Add username hostname and port to psql calls

### DIFF
--- a/lib/snowflakes/commands/database_config.rb
+++ b/lib/snowflakes/commands/database_config.rb
@@ -11,11 +11,15 @@ module Snowflakes
       end
 
       def username
-        uri.user || ''
+        uri.user || nil
       end
 
       def port
         uri.port || 5432
+      end
+
+      def username_flag
+        username ? "-U #{username}" : ""
       end
 
       def db_name

--- a/lib/snowflakes/commands/database_config.rb
+++ b/lib/snowflakes/commands/database_config.rb
@@ -10,6 +10,14 @@ module Snowflakes
         uri.hostname
       end
 
+      def username
+        uri.user || ''
+      end
+
+      def port
+        uri.port || 5432
+      end
+
       def db_name
         @db_name ||= uri.path.gsub(/^\//, '')
       end

--- a/lib/snowflakes/commands/db/create.rb
+++ b/lib/snowflakes/commands/db/create.rb
@@ -5,7 +5,7 @@ module Snowflakes
     module Db
       class Create < DatabaseConfig
         def start
-          `createdb #{db_name} -h #{hostname}  -p #{port} -U #{username}`
+          `createdb #{db_name} -h #{hostname}  -p #{port} #{username_flag}`
           puts "=> database #{db_name} created"
         end
       end

--- a/lib/snowflakes/commands/db/create.rb
+++ b/lib/snowflakes/commands/db/create.rb
@@ -5,7 +5,7 @@ module Snowflakes
     module Db
       class Create < DatabaseConfig
         def start
-          `createdb #{db_name}`
+          `createdb #{db_name} -h #{hostname}  -p #{port} -U #{username}`
           puts "=> database #{db_name} created"
         end
       end

--- a/lib/snowflakes/commands/db/drop.rb
+++ b/lib/snowflakes/commands/db/drop.rb
@@ -5,7 +5,7 @@ module Snowflakes
     module Db
       class Drop < DatabaseConfig
         def start
-          `dropdb #{db_name}`
+          `dropdb #{db_name} -h #{hostname} -p #{port} -U #{username}`
           puts "=> database #{db_name} dropped"
         end
       end

--- a/lib/snowflakes/commands/db/drop.rb
+++ b/lib/snowflakes/commands/db/drop.rb
@@ -5,7 +5,7 @@ module Snowflakes
     module Db
       class Drop < DatabaseConfig
         def start
-          `dropdb #{db_name} -h #{hostname} -p #{port} -U #{username}`
+          `dropdb #{db_name} -h #{hostname} -p #{port} #{username_flag}`
           puts "=> database #{db_name} dropped"
         end
       end

--- a/lib/snowflakes/commands/db/structure/dump.rb
+++ b/lib/snowflakes/commands/db/structure/dump.rb
@@ -7,7 +7,7 @@ module Snowflakes
         class Dump < Database
           def start
             measure("#{db_name} structure dumped to #{output_file}") do
-              system(%(pg_dump -h #{hostname}  -p #{port} -U #{username} --schema-only --no-owner #{db_name} > #{output_file}))
+              system(%(pg_dump -h #{hostname}  -p #{port} #{username_flag} --schema-only --no-owner #{db_name} > #{output_file}))
             end
           end
 

--- a/lib/snowflakes/commands/db/structure/dump.rb
+++ b/lib/snowflakes/commands/db/structure/dump.rb
@@ -7,7 +7,7 @@ module Snowflakes
         class Dump < Database
           def start
             measure("#{db_name} structure dumped to #{output_file}") do
-              system(%(pg_dump -h #{hostname} --schema-only --no-owner #{db_name} > #{output_file}))
+              system(%(pg_dump -h #{hostname}  -p #{port} -U #{username} --schema-only --no-owner #{db_name} > #{output_file}))
             end
           end
 


### PR DESCRIPTION
This PR allows us to grab the username and port number for postgres bin calls. Useful if we're trying to connect to an instance of postgres running on docker / some other remote server.