### PR TITLE
Allow client apps to configure max_connections.

### DIFF
--- a/lib/snowflakes/components/persistence.rb
+++ b/lib/snowflakes/components/persistence.rb
@@ -7,6 +7,7 @@ Dry::System.register_component(:persistence, provider: :snowflakes) do
     key :connection_extensions, Types::Array.of(Types::Symbol)
     key :auto_registration_root, Types::String.optional.default(nil)
     key :auto_registration_namespace, Types::String.optional.default(nil)
+    key :max_connections, Types::Integer.optional.default(4)
   end
 
   init do
@@ -24,6 +25,7 @@ Dry::System.register_component(:persistence, provider: :snowflakes) do
     rom_config = ROM::Configuration.new(
       :sql,
       config.database_url,
+      max_connections: config.max_connections,
       extensions: config.connection_extensions
     )
 


### PR DESCRIPTION
Client applications should be able to set the max_connections value (i.e. decide the maximum pool size) for the database connection. The default value for this in Sequel is 4. I've set that default here, which will allow client applications to avoid specifying this setting should they wish. 

With this change, setting a pool size of 8 from example the RRR app would look like:

```ruby
configure do |config|
  config.database_url = container.settings.database_url
  config.max_connections = 8
  config.global_extensions = [:postgres]
  config.connection_extensions = %i[error_sql pg_array pg_json pg_enum]
end
```

I've confirmed this increases the number of connections to the database locally.